### PR TITLE
Remove SensESP from the library's platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -21,7 +21,6 @@ framework = arduino
 lib_ldf_mode = deep
 monitor_speed = 115200
 lib_deps =
-   SignalK/SensESP
    https://github.com/SensESP/INA2xx.git
 
 [espressif8266_base]


### PR DESCRIPTION
Per discussion w/ @mairas, this shouldn't be here. It should be ONLY in an individual project's platformio.ini.