### PR TITLE
Bug fix: deviceNum not properly initialized in constructor

### DIFF
--- a/src/ina2xx.cpp
+++ b/src/ina2xx.cpp
@@ -32,7 +32,7 @@ INA2xxValue::INA2xxValue(INA2xx* ina2xx, uint8_t deviceNum,
                          String config_path)
     : NumericSensor(config_path),
       ina2xx_{ina2xx},
-      deviceNum_{deviceNum_},
+      deviceNum_{deviceNum},
       val_type_{val_type},
       read_delay_{read_delay} {
   load_configuration();


### PR DESCRIPTION
was: deviceNum_{deviceNum_};
is now: deviceNum_{deviceNum};

Bug caused all value readings to come from channel 0 of all INA devices.